### PR TITLE
Sunro/1주차/월요일

### DIFF
--- a/DFS&BFS/Sunro/그림_1926.java
+++ b/DFS&BFS/Sunro/그림_1926.java
@@ -1,0 +1,66 @@
+package Sunro;
+
+import java.io.*;
+import java.util.*;
+
+/*
+그림 없을때는 카운트와 넓이 모두 0출력
+BFS로 구현하기 - queue
+ */
+public class 그림_1926 {
+    static int[] dx = {0,1,0,-1};
+    static int[] dy = {-1,0,1,0};
+    static int N,M; //<=500
+    static boolean[][] visited;
+    static int[][] map;
+    public static void main(String[] args) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st= new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        visited = new boolean[N][M];
+        map = new int[N][M];
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < M; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        int count=0;
+        int maxCount =0;
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                if (map[i][j] == 1 && !visited[i][j]) {
+                    count++;
+                    maxCount= Math.max(BFS(i,j),maxCount);
+                }
+            }
+        }
+
+        System.out.println(count);
+        System.out.println(maxCount);
+
+    }
+
+    private static int BFS(int i, int j) {
+        Queue<int[]> queue = new LinkedList<>();
+        queue.add(new int[]{i,j});
+        visited[i][j] = true;
+        int cnt =1;
+        while (!queue.isEmpty()) {
+            int[] poll = queue.poll();
+            for (int k = 0; k < 4; k++) {
+                int x = poll[0] + dx[k];
+                int y = poll[1] + dy[k];
+                if (x >= 0 && y >= 0 && x < N && y < M && !visited[x][y] && map[x][y]==1) {
+                    queue.add(new int[]{x,y});
+                    visited[x][y] = true;
+                    cnt++;
+                }
+            }
+        }
+        return cnt;
+    }
+}

--- a/DFS&BFS/Sunro/유기농배추_1012.java
+++ b/DFS&BFS/Sunro/유기농배추_1012.java
@@ -1,0 +1,65 @@
+package Sunro;
+
+import java.util.*;
+import java.io.*;
+
+
+public class 유기농배추_1012 {
+    static int[] dx = {0,1,0,-1};
+    static int[] dy = {-1,0,1,0};
+    static int R, C, N, M; //R = 반복수  , C = 몇 개 심어져있는지, N,M 지도
+    static int[][] map;
+    static boolean[][] visited;
+
+    public static void main(String[] args) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        R = Integer.parseInt(br.readLine());
+
+
+
+//        시간복잡도 R * NM
+        while (R-->0) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            N = Integer.parseInt(st.nextToken());
+            M = Integer.parseInt(st.nextToken());
+            C = Integer.parseInt(st.nextToken());
+
+            map = new int[N+1][M+1];
+            visited = new boolean[N+1][M+1];
+
+            for (int i = 0; i < C; i++) {
+                st = new StringTokenizer(br.readLine());
+                int x = Integer.parseInt(st.nextToken());
+                int y = Integer.parseInt(st.nextToken());
+                map[x][y] = 1;
+            }
+            int count =0;
+
+            for (int i = 0; i < N; i++) {
+                for (int j = 0; j < M; j++) {
+                    if(map[i][j]==1 && !visited[i][j]){
+                        BFS(i,j);
+                        count++;
+                    }
+                }
+            }
+            System.out.println(count);
+        }
+    }
+    private static void BFS(int x, int y) {
+        Queue<int[]> queue = new LinkedList<>();
+        queue.add(new int[]{x, y});
+        visited[x][y] = true;
+        while (!queue.isEmpty()) {
+            int[] poll = queue.poll();
+            for (int i = 0; i < 4; i++) {
+                int nx = poll[0] + dx[i];
+                int ny = poll[1] + dy[i];
+                if(nx>=0 && ny>=0 && nx<N && ny<M && !visited[nx][ny] && map[nx][ny] == 1){
+                    queue.add(new int[]{nx, ny});
+                    visited[nx][ny] = true;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
문제 회고를 위해 알고리즘 풀이 기록을 남깁니다.
    
### 문제 이해하기
1. 그림
값이 1 인 배열을 탐색하고 가장 넓은 범위, 그림의 수를 측정한다.

2. 유기농배추
값이 1인 배열을 탐색하고 탐색을 수행한 수를 측정한다.

### 문제 접근 방법
DFS를 통해 그래프를 만들고 각 방문 배열을 Queue방식으로 add한다. 방문 배열에 한 번 접근한 배열은 다시 방문하지 않는다.
BFS보다 DFS를 통해 상하좌우로 빠른 탐색이 가능하다 생각함.

### 구현 배경 지식
DFS를 사용하여 현재 배열위치 기준 상하좌우의 노드들을 탐색한다.

### 접근 방법을 적용한 코드
```java
 static int[] dx = {0,1,0,-1}; // 고정적으로 이동할 x 좌표
    static int[] dy = {-1,0,1,0}; // 고정적으로 이동할 y 좌표
    static boolean[][] visited; //방문 배열
    static int[][] map; //현재 위치를 나타낼 2차원 배열

//BFS 탐색 코드
private static int BFS(int i, int j) {
        Queue<int[]> queue = new LinkedList<>();
        queue.add(new int[]{i,j});
        visited[i][j] = true;
        int cnt =1;
        while (!queue.isEmpty()) {
            int[] poll = queue.poll();
            for (int k = 0; k < 4; k++) {
                int x = poll[0] + dx[k];
                int y = poll[1] + dy[k];
                if (x >= 0 && y >= 0 && x < N && y < M && !visited[x][y] && map[x][y]==1) {
                    queue.add(new int[]{x,y});
                    visited[x][y] = true;
                    cnt++;
                }
            }
        }
        return cnt;
    }
```

### 해결하지 못한 이유
중간에  map[x][y]==1 조건을 넣지 않아서 전체를 탐색해버리는 문제가 발생헀으나 발견하고 해결

### 문제를 해결한 코드
```java
  if (x >= 0 && y >= 0 && x < N && y < M && !visited[x][y] && map[x][y]==1) {
```

### 문제를 해결한 방법
디버깅!

