### PR TITLE
Jiyun/1주차/금요일

### DIFF
--- a/DFS&BFS/jiyun/나이트의이동_7562.java
+++ b/DFS&BFS/jiyun/나이트의이동_7562.java
@@ -1,0 +1,62 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class 나이트의이동_7562 { // BOJ_7562_나이트의 이동
+
+    static int[] dr = {-1, 1, 0, 0};
+    static int[] dc = {0, 0, -1, 1};
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int t = Integer.parseInt(br.readLine());
+
+        for (int tc =0; tc<t; tc++){
+            int n = Integer.parseInt(br.readLine()); // 한 변의 길이
+
+
+            // 현재 칸
+            st = new StringTokenizer(br.readLine());
+            int cr = Integer.parseInt(st.nextToken());
+            int cc = Integer.parseInt(st.nextToken());
+
+            // 이동하려는 칸
+            st = new StringTokenizer(br.readLine());
+            int ar = Integer.parseInt(st.nextToken());
+            int ac = Integer.parseInt(st.nextToken());
+
+            bfs(cr, cc, ar, ac, n);
+        } // tc end
+    }
+
+    private static void bfs(int cr, int cc, int ar, int ac, int n){
+        boolean[][] visited = new boolean[n][n];
+
+        ArrayDeque<int[]> q = new ArrayDeque<>();
+        q.offer(new int[] {cr, cc, 0}); // r, c, 이동 횟수
+        visited[cr][cc] = true;
+
+        while (!q.isEmpty()){
+            int[] cur = q.poll();
+
+            if (cur[0] == ar && cur[1] == ac){
+                System.out.println(cur[2]);
+                return;
+            }
+
+            for (int d=0; d<8; d++){
+                int nr = cur[0] + dr[d];
+                int nc = cur[1] + dc[d];
+
+                if (nr < 0 || nc < 0 || nr >= n || nc >= n || visited[nr][nc]) continue;
+                q.add(new int[] {nr, nc, cur[2]+1});
+                visited[nr][nc] = true;
+            }
+
+        }
+
+    }
+}

--- a/DFS&BFS/jiyun/미로탐색_2178.java
+++ b/DFS&BFS/jiyun/미로탐색_2178.java
@@ -1,0 +1,60 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class 미로탐색_2178 { // BOJ_2178_미로탐색
+
+    static char[][] miro;
+    static boolean[][] visit;
+    static int[] dr = {-1, 1, 0, 0};
+    static int[] dc = {0, 0, -1, 1};
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+
+        miro = new char[n][m];
+        visit = new boolean[n][m];
+
+        for (int i = 0; i < n; i++) {
+            String str = br.readLine();
+            for (int j = 0; j < m; j++) {
+                miro[i][j] = str.charAt(j);
+            }
+        }
+
+        // 1은 이동 가능, 0은 이동 불가능
+        bfs(n, m);
+    }
+
+    private static void bfs(int n, int m){
+        ArrayDeque<int[]> q = new ArrayDeque<>();
+
+        // (0,0)에서 시작 도착은 (n-1,m-1)
+        q.offer(new int[] {0, 0, 1}); // r, c, 칸 수
+        visit[0][0] = true;
+
+        while (!q.isEmpty()){
+            int[] cur = q.poll();
+
+            if (cur[0] == n-1 && cur[1] == m-1){
+                System.out.println(cur[2]);
+                return;
+            }
+
+            for (int d=0; d<4; d++){
+                int nr = cur[0] + dr[d];
+                int nc = cur[1] + dc[d];
+                if (nr < 0 || nc < 0 || nr >= n || nc >= m) continue;
+                if (visit[nr][nc] || miro[nr][nc] == '0') continue;
+                q.offer(new int[] {nr, nc, cur[2]+1});
+                visit[nr][nc] = true; // 방문 처리 위치
+
+            }
+        }
+    }
+}

--- a/DFS&BFS/jiyun/불_5427.java
+++ b/DFS&BFS/jiyun/불_5427.java
@@ -1,0 +1,87 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class 불_5427 { // BOJ_5427_불
+
+    static int[] dr = {-1, 1, 0, 0};
+    static int[] dc = {0, 0, -1, 1};
+    static char[][] map;
+    static boolean[][] visited;
+    static ArrayDeque<int[]> sangQ;
+    static ArrayDeque<int[]> fireQ;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int T = Integer.parseInt(br.readLine());
+        for (int tc =0; tc<T; tc++){
+            st = new StringTokenizer(br.readLine());
+            int w = Integer.parseInt(st.nextToken()); // 지도 너비 c
+            int h = Integer.parseInt(st.nextToken()); // 지도 높이 r
+
+            map = new char[h][w];
+            visited = new boolean[h][w];
+
+            sangQ = new ArrayDeque<>();
+            fireQ = new ArrayDeque<>();
+
+            for (int i = 0; i < h; i++){
+                String str = br.readLine();
+                for (int j = 0; j < w; j++){
+                    char ch = str.charAt(j);
+                    if (ch == '@'){
+                        sangQ.add(new int[] {i, j, 1});
+                    }
+                    if (ch == '*'){
+                        fireQ.add(new int[] {i, j});
+                    }
+                    map[i][j] = ch;
+                }
+            } // map end
+
+            bfs(h, w);
+        }
+    }
+
+    private static void bfs(int h, int w){
+        while (!sangQ.isEmpty()){
+            int firesize = fireQ.size();
+            int sangsize = sangQ.size();
+            for (int i = 0; i < firesize; i++){
+                int[] fire = fireQ.poll();
+
+                for (int d = 0; d < 4; d++){
+                    int nr = fire[0] + dr[d];
+                    int nc = fire[1] + dc[d];
+
+                    if (nr < 0 || nc < 0 || nr >= h || nc >= w || map[nr][nc] == '#' || map[nr][nc] == '*') continue;
+
+                    fireQ.add(new int[] {nr, nc});
+                    map[nr][nc] = '*';
+                }
+            }
+
+            for (int i = 0; i < sangsize; i++){
+                int[] sang = sangQ.poll();
+                int cr = sang[0];
+                int cc = sang[1];
+                if (cr == 0 || cc == 0 || cr == h-1 || cc == w-1) { // 출구 판별
+                    System.out.println(sang[2]);
+                    return;
+                }
+                for (int d = 0; d < 4; d++){
+                    int nr = sang[0] + dr[d];
+                    int nc = sang[1] + dc[d];
+
+                    if (nr < 0 || nc < 0 || nr >= h || nc >= w || map[nr][nc] != '.' || visited[nr][nc]) continue;
+                    sangQ.add(new int[] {nr, nc, sang[2]+1});
+                    visited[nr][nc] = true;
+                }
+            }
+        }
+        System.out.println("IMPOSSIBLE");
+    }
+}


### PR DESCRIPTION
문제 회고를 위해 알고리즘 풀이 기록을 남깁니다.
    
### 문제 이해하기
<불>
- 불과 상근이가 동시에 움직이도록 각자의 큐를 활용하여 최적의 탈출 루트 탐색

### 문제 접근 방법
두 개의 큐를 활용하여 상근이의 이동과 불의 이동을 탐색하였으며, 방문 체크를 통해 최단 루트 탐색

### 구현 배경 지식
BFS

### 접근 방법을 적용한 코드
```
            for (int i = 0; i < h; i++){
                String str = br.readLine();
                for (int j = 0; j < w; j++){
                    char ch = str.charAt(j);
                    if (ch == '@'){
                        sangQ.add(new int[] {i, j, 1});
                    }
                    if (ch == '*'){
                        fireQ.add(new int[] {i, j});
                    }
                    map[i][j] = ch;
                }
            } // map end
```

- 방문 체크의 경우, 불은 따로 방문 배열을 두지 않고, map의 값을 변경했다.
```
fireQ.add(new int[] {nr, nc});
 map[nr][nc] = '*';

sangQ.add(new int[] {nr, nc, sang[2]+1});
visited[nr][nc] = true;
```
### 해결하지 못한 이유
1. 종료 조건 착각
출구를 판별하는 조건문의 조건을 잘못 작성했다.

2. 너비 탐색의 depth를 제어하여 두개의 큐가 같은 시간대를 유지하도록 하지 못함
설명이 어렵다.
1초동안의 불의 확산 범위 탐색, 상근이 이동 범위 탐색이 각각 이루어져야 한다.

### 문제를 해결한 코드
```
        while (!sangQ.isEmpty()){
            int firesize = fireQ.size();
            int sangsize = sangQ.size();
            for (int i = 0; i < firesize; i++){
                int[] fire = fireQ.poll();

                for (int d = 0; d < 4; d++){
                    int nr = fire[0] + dr[d];
                    int nc = fire[1] + dc[d];

                    if (nr < 0 || nc < 0 || nr >= h || nc >= w || map[nr][nc] == '#' || map[nr][nc] == '*') continue;

                    fireQ.add(new int[] {nr, nc});
                    map[nr][nc] = '*';
                }
            }

            for (int i = 0; i < sangsize; i++){
                int[] sang = sangQ.poll();
                int cr = sang[0];
                int cc = sang[1];
                if (cr == 0 || cc == 0 || cr == h-1 || cc == w-1) { // 출구 판별
                    System.out.println(sang[2]);
                    return;
                }
                for (int d = 0; d < 4; d++){
                    int nr = sang[0] + dr[d];
                    int nc = sang[1] + dc[d];

                    if (nr < 0 || nc < 0 || nr >= h || nc >= w || map[nr][nc] != '.' || visited[nr][nc]) continue;
                    sangQ.add(new int[] {nr, nc, sang[2]+1});
                    visited[nr][nc] = true;
                }
            }
        }
```

### 문제를 해결한 방법
불 큐의 크기만큼 너비 탐색 후, 상근이 큐의 크기만큼 너비 탐색을 진행하는 방식으로 상근이 큐에 값이 없을 때까지 반복

### 자주 틀리는 부분
큐의 크기만큼 반복하는 코드 작성할 때마다 틀리는 부분이다.
```
int firesize = fireQ.size();
int sangsize = sangQ.size();
for (int i = 0; i < firesize; i++){
```
해당 부분에서 동적으로 변경되는 큐의 사이즈를 직접 넣어 오류가 발생한 적이 많다.
