### PR TITLE
Jiyun/2주차

### DIFF
--- a/DP/jiyun/BOJ_14501_퇴사.java
+++ b/DP/jiyun/BOJ_14501_퇴사.java
@@ -1,0 +1,31 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ_14501_퇴사 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int n = Integer.parseInt(br.readLine());
+        int[] time = new int[n + 1];
+        int[] pay = new int[n + 1];
+        int[] dp = new int[n + 2]; // n일 째 부터 일한 값 중 최대 이익
+
+        for(int i=1; i<n+1; i++){
+            st = new StringTokenizer(br.readLine());
+            time[i] = Integer.parseInt(st.nextToken());
+            pay[i] = Integer.parseInt(st.nextToken());
+        }
+
+        for (int i=n; i>0; i--){
+            if(i + time[i] > n+1) {
+                dp[i] = dp[i+1];
+            } else {
+                dp[i] = Math.max(dp[i+1], pay[i] + dp[i+time[i]]);
+            }
+        }
+        System.out.println(dp[1]);
+    }
+}

--- a/DP/jiyun/BOJ_9461_파도반수열.java
+++ b/DP/jiyun/BOJ_9461_파도반수열.java
@@ -1,0 +1,25 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ_9461_파도반수열 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int T = Integer.parseInt(br.readLine());
+
+        long[] p = new long[101];
+        p[1] = 1;
+        p[2] = 1;
+        p[3] = 1;
+
+        for (int i=4; i<101; i++){
+            p[i] = p[i-3] + p[i-2];
+        }
+
+        for (int tc=0; tc<T; tc++){
+            int n = Integer.parseInt(br.readLine());
+            System.out.println(p[n]);
+        }
+    }
+}


### PR DESCRIPTION
문제 회고를 위해 알고리즘 풀이 기록을 남깁니다.
    
### 문제 이해하기
- 파도반 수열

- 퇴사
상담이 가능한 날짜를 잘 분배하여 최대 비용을 얻기

### 문제 접근 방법
- 파도반 수열
예시로 주어진 수열의 규칙을 찾기

- 퇴사
최대 값을 얻기 위해서 마지막 날부터 접근하기

### 구현 배경 지식

### 접근 방법을 적용한 코드
```
        for (int i=n; i>0; i--){
            if(i + time[i] > n+1) {
                dp[i] = dp[i+1];
            } else {
                dp[i] = Math.max(dp[i+1], pay[i] + dp[i+time[i]]);
            }
        }
```

### 해결하지 못한 이유
- 퇴사
마지막 날부터 접근해야하는 건 알겠는데 최대값을 어떻게 갱신하는지 찾지 못함

### 문제를 해결한 코드
```
        for (int i=n; i>0; i--){
            if(i + time[i] > n+1) {
                dp[i] = dp[i+1];
            } else {
                dp[i] = Math.max(dp[i+1], pay[i] + dp[i+time[i]]);
            }
        }
```

### 문제를 해결한 방법
- 오랜 고민과 시도 끝에 블로그 글을 참고함. 추후에 정답을 보지 않고 다시 풀어볼 예정
